### PR TITLE
Add utf-8 charset in ics headers

### DIFF
--- a/_public.php
+++ b/_public.php
@@ -675,7 +675,7 @@ class urlEventHandler extends dcUrlHandlers
 
 		$res .= "END:VCALENDAR\r\n";
 
-		header('Content-Type: text/calendar');
+		header('Content-Type: text/calendar; charset=utf-8');
 		header('Content-Length: '.strlen($res));
 		header('Content-Disposition: attachment; filename="events.ics"');
 		echo $res;


### PR DESCRIPTION
This is required in order to work correctly with google agenda
