### PR TITLE
* Fixed a bug related to deprecated behaviors in dotclear 2.6

### DIFF
--- a/_admin.php
+++ b/_admin.php
@@ -39,9 +39,7 @@ if ($core->blog->settings->eventHandler->active)
 {
 	$core->addBehavior('adminPostHeaders',array('adminEventHandler','adminPostHeaders'));
 	$core->addBehavior('adminPostsActionsCombo',array('adminEventHandler','adminPostsActionsCombo'));
-	$core->addBehavior('adminPostsActionsHeaders',array('adminEventHandler','adminPostsActionsHeaders'));
-	$core->addBehavior('adminPostsActions',array('adminEventHandler','adminPostsActions'));
-	$core->addBehavior('adminPostsActionsContent',array('adminEventHandler','adminPostsActionsContent'));
+	$core->addBehavior('adminPostsActionsPage',array('adminEventHandler','adminPostsActionsPage'));
 	$core->addBehavior('adminPostFormSidebar',array('adminEventHandler','adminPostFormSidebar'));
 	$core->addBehavior('adminAfterPostCreate',array('adminEventHandler','adminAfterPostSave'));
 	$core->addBehavior('adminAfterPostUpdate',array('adminEventHandler','adminAfterPostSave'));
@@ -91,87 +89,63 @@ class adminEventHandler
 		$args[0][__('Events')][__('Unbind events')] = 'eventhandler_remove_event';
 	}
 
-	# posts_actions.php
-	# Headers for table of events
-	public static function adminPostsActionsHeaders()
-	{
-		return
-		'<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/style.css" />';
+	public static function adminPostsActionsPage($core,dcPostsActionsPage $ap){
+		if ($core->auth->check('publish,contentadmin',$core->blog->id)) {
+			$ap->addAction(array(__('Events') => array(
+					__('Bind events') => 'eventhandler_bind_event',
+					__('Unbind events') => 'eventhandler_unbind_post'
+				)),
+				array('adminEventHandler','doBindUnbind')
+			);
+		}
 	}
+	
+	public static function doBindUnBind($core, dcPostsActionsPage $ap, $post){
+		$action = $ap->getAction();
+		if($action!='eventhandler_bind_event' && $action!='eventhandler_unbind_post')
+			return;
+		
+		$posts_ids = $ap->getIDs();
+		if (empty($posts_ids)) {
+			throw new Exception(__('No entry selected'));
+		}
+		$params['sql'] = ' AND P.post_id '.$core->con->in($posts_ids).' ';
+		$posts = $core->blog->getPosts($params);
 
-	# posts_actions.php
-	# Action for multiple posts and actions for multiple events
-	public static function adminPostsActions($core,$posts,$action,$redir)
-	{
-		# Bind selected events to selected posts
-		if ($action == 'eventhandler_bind_event' && !empty($_POST['events']))
-		{
-			try
-			{
-				foreach ($_POST['events'] as $k => $v)
-				{
+		if($action == 'eventhandler_bind_event'){
+			if(isset($post['events'])){
+				foreach ($post['events'] as $k => $v)	{
 					$events_id[$k] = (integer) $v;
 				}
-				$params['sql'] = 'AND P.post_id IN('.implode(',',$events_id).') ';
+				$params['sql'] = 'AND P.post_id '.$core->con->in($events_id).' ';
 				$eventHandler = new eventHandler($core);
 				$events = $eventHandler->getEvents($params);
-
-				if ($events->isEmpty())
-				{
+				if ($events->isEmpty()) {
 					throw new Exception(__('No such event'));
 				}
 				$meta_ids = array();
-				while ($events->fetch())
-				{
+				while ($events->fetch()) {
 					$meta_ids[] = $events->post_id;
 				}
 
-				while ($posts->fetch())
-				{
-					foreach($meta_ids as $meta_id)
-					{
+				while ($posts->fetch()) {
+					foreach($meta_ids as $meta_id)	{
 						$core->meta->delPostMeta($posts->post_id,'eventhandler',$meta_id);
 						$core->meta->setPostMeta($posts->post_id,'eventhandler',$meta_id);
 					}
 				}
-
-				http::redirect($redir);
-			}
-			catch (Exception $e)
-			{
-				$core->error->add($e->getMessage());
-			}
-		}
-		# Unbind all posts from selected events
-		if ($action == 'eventhandler_unbind_post')
-		{
-			try
-			{
-				while ($posts->fetch())
-				{
-					$core->meta->delMeta($posts->post_id,'eventhandler');
-				}
-
-				http::redirect($redir);
-			}
-			catch (Exception $e)
-			{
-				$core->error->add($e->getMessage());
-			}
-		}
-	}
-
-	# posts_actions.php
-	# Form for action on multiple posts
-	# (action on one post can be found on index.php?part=events&from_id=xxx)
-	public static function adminPostsActionsContent($core,$action,$hidden_fields)
-	{
-		if ($action == 'eventhandler_bind_event')
-		{
-			echo '<h3>'.__('Select events to link to entries').'</h3>';
-
-			try
-			{
+				dcPage::addSuccessNotice(sprintf(
+					__(
+						'%d entry has been successfully bound %s',
+						'%d entries have been successfully bound %s',
+						count($posts_ids)
+					),
+					count($posts_ids),__('to the selected event','to the selected events',$events->count()))
+				);
+				$ap->redirect(true);			
+			}else{
+				$ap->beginPage('','<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/style.css" />');
+				echo '<h3>'.__('Select events to link to entries').'</h3>';
 				$eventHandler = new eventHandler($core);
 
 				$params = array();
@@ -179,6 +153,9 @@ class adminEventHandler
 				$params['order'] = 'event_startdt DESC';
 				$params['period'] = 'notfinished';
 
+				# --BEHAVIOR-- adminEventHandlerMinilistCustomize 
+				$core->callBehavior('adminEventHandlerMinilistCustomize',array('params'=>&$params));
+				
 				$events = $eventHandler->getEvents($params);
 				$counter = $eventHandler->getEvents($params,true);
 				$list = new adminEventHandlerMiniList($core,$events,$counter->f(0));
@@ -189,20 +166,61 @@ class adminEventHandler
 					'%s'.
 
 					'<p>'.
-					$hidden_fields.
+					$ap->getHiddenFields().
+					$ap->getIDsHidden().
 					$core->formNonce().
 					form::hidden(array('action'),'eventhandler_bind_event').
 					'<input type="submit" value="'.__('save').'" /></p>'.
 					'</form>'
 				);
+				$ap->endPage();
 			}
-			catch (Exception $e)
-			{
-				$core->error->add($e->getMessage());
+		}	
+		# Unbind all posts from selected events
+		if ($action == 'eventhandler_unbind_post')	{
+			if(!$posts->isEmpty()){ //called from posts.php
+				while ($posts->fetch()) {
+					$core->meta->delPostMeta($posts->post_id,'eventhandler');
+				}
+			dcPage::addSuccessNotice(sprintf(
+				__(
+					'%d post has been successfully unbound from its events',
+					'%d posts have been successfully unbound from their events',
+					count($posts_ids)
+				),
+				count($posts_ids)));
+			}else if(isset($post['entries'])){
+				$eventHandler = new eventHandler($core);
+				foreach ($post['entries'] as $k => $v)	{
+					$params=array('event_id'=>$v);
+					$posts=$eventHandler->getPostsByEvent($params);
+					$event=$eventHandler->getEvents($params);
+					if($posts->isEmpty()){
+						dcPage::addWarningNotice(sprintf(
+						__('Event #%d (%s) has no related post to be unbound from.'),
+						$v,$event->post_title));
+						continue;
+					}
+					while ($posts->fetch()) {
+						$core->meta->delPostMeta($posts->post_id,'eventhandler',$v);
+					}
+					dcPage::addSuccessNotice(sprintf(
+					__(
+						'Event #%d (%s) successfully unbound from %d related post',
+						'Event #%d (%s) successfully unbound from %d related posts',
+						$posts->count()
+					),
+					$v,$event->post_title,$posts->count()));
+				}
+				$ap->redirect(false);			
+			}else{
+				throw new Exception("adminEventhandler::doBindUnBind Should never happen, $action action called with no post nor event specified.");
 			}
+			$ap->redirect(true);			
 		}
+		$ap->redirect(false);
 	}
-
+	
 	# post.php
 	# Sidebar list of linked events, menu of events actions for this post
 	public static function adminPostFormSidebar($post)
@@ -336,14 +354,18 @@ class adminEventHandlerMiniList extends adminGenericList
 			$pager->html_next = $this->html_next;
 			$pager->var_page = 'page';
 
+			$columns=array('<th colspan="2">'.__('Title').'</th>',
+				'<th>'.__('Period').'</th>',
+                '<th>'.__('Start date').'</th>',
+                '<th>'.__('End date').'</th>',
+                '<th>'.__('Status').'</th>');
+			
+			# --BEHAVIOR-- adminEventHandlerEventsListHeader
+			$this->core->callBehavior('adminEventHandlerEventsListHeaders',array('columns'=>&$columns),true);
 			$html_block =
-			'<table class="clear"><tr>'.
-			'<th colspan="2">'.__('Title').'</th>'.
-			'<th>'.__('Period').'</th>'.
-			'<th>'.__('Start date').'</th>'.
-			'<th>'.__('End date').'</th>'.
-			'<th>'.__('Status').'</th>'.
-			'</tr>%s</table>';
+                '<table class="clear"><tr>'.
+   			join('',$columns).
+            '</tr>%s</table>';
 
 			if ($enclose_block) {
 				$html_block = sprintf($enclose_block,$html_block);
@@ -399,15 +421,20 @@ class adminEventHandlerMiniList extends adminGenericList
 		$period = $this->rs->getPeriod();
 		$style = ' eventhandler-'.$period;
 
+		$columns=array('<td class="nowrap">'.form::checkbox(array('events[]'),$this->rs->post_id,'','','',!$this->rs->isEditable()).'</td>'.
+			'<td><a href="'.$this->core->getPostAdminURL($this->rs->post_type,$this->rs->post_id).'" '.
+			'title="'.html::escapeHTML($this->rs->getURL()).'">'.html::escapeHTML($this->rs->post_title).'</a></td>',
+			'<td class="nowrap'.$style.'">'.__($period).'</td>',
+			'<td class="nowrap">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_startdt).'</td>',
+            '<td class="nowrap">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_enddt).'</td>',
+            '<td class="nowrap status">'.$img_status.' '.$selected.' '.$protected.'</td>');
+
+			# --BEHAVIOR-- adminEventHandlerEventsListBody
+			$this->core->callBehavior('adminEventHandlerEventsListBody',$this->rs,array('columns'=>&$columns),true);
+
 		return
 		'<tr class="line'.($this->rs->post_status != 1 ? ' offline' : '').$style.'" id="e'.$this->rs->post_id.'">'.
-		'<td class="nowrap">'.form::checkbox(array('events[]'),$this->rs->post_id,'','','',!$this->rs->isEditable()).'</td>'.
-		'<td><a href="'.$this->core->getPostAdminURL($this->rs->post_type,$this->rs->post_id).'" '.
-		'title="'.html::escapeHTML($this->rs->getURL()).'">'.html::escapeHTML($this->rs->post_title).'</a></td>'.
-		'<td class="nowrap'.$style.'">'.__($period).'</td>'.
-		'<td class="nowrap">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_startdt).'</td>'.
-		'<td class="nowrap">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_enddt).'</td>'.
-		'<td class="nowrap status">'.$img_status.' '.$selected.' '.$protected.'</td>'.
+        join("",$columns).
 		'</tr>';
 	}
 }

--- a/_define.php
+++ b/_define.php
@@ -20,6 +20,6 @@ $this->registerModule(
 	/* Name */			"Event handler",
 	/* Description*/		"Add period to your posts",
 	/* Author */			"JC Denis, Nicolas Roudaire",
-	/* Version */			'2014.12.17',
+	/* Version */			'2015.03.21',
 	/* Permissions */		'usage,contentadmin'
 );

--- a/_install.php
+++ b/_install.php
@@ -3,7 +3,7 @@
 #
 # This file is part of eventHandler, a plugin for Dotclear 2.
 #
-# Copyright(c) 2014 Nicolas Roudaire <nikrou77@gmail.com> http://www.nikrou.net
+# Copyright(c) 2014-2015 Nicolas Roudaire <nikrou77@gmail.com> http://www.nikrou.net
 #
 # Copyright (c) 2009-2013 Jean-Christian Denis and contributors
 # contact@jcdenis.fr http://jcd.lv
@@ -14,8 +14,14 @@
 #
 # -- END LICENSE BLOCK ------------------------------------
 
+define('EH_DC_MIN_VERSION','2.6');
 if (!defined('DC_CONTEXT_ADMIN')){return;}
 
+if (version_compare(DC_VERSION,EH_DC_MIN_VERSION,'<')) {
+	$core->error->add(sprintf(__('Dotclear version %s minimum is required. "%s" is deactivated',EH_DC_MIN_VERSION,'eventHandler')));
+	$core->plugins->deactivateModule('eventHandler');
+	return false;
+}
 # Get new version
 $new_version = $core->plugins->moduleInfo('eventHandler','version');
 $old_version = $core->getVersion('eventHandler');

--- a/inc/admin.event_handler.list.php
+++ b/inc/admin.event_handler.list.php
@@ -3,7 +3,7 @@
 #
 # This file is part of eventHandler, a plugin for Dotclear 2.
 #
-# Copyright(c) 2014 Nicolas Roudaire <nikrou77@gmail.com> http://www.nikrou.net
+# Copyright(c) 2014-2015 Nicolas Roudaire <nikrou77@gmail.com> http://www.nikrou.net
 #
 # Licensed under the GPL version 2.0 license.
 # A copy of this license is available in LICENSE file or at
@@ -23,17 +23,21 @@ class adminEventHandlertList extends adminGenericList
 			$pager->html_next = $this->html_next;
 			$pager->var_page = 'page';
 
+			$columns=array('<th colspan="2">'.__('Title').'</th>',
+                '<th>'.__('Start date').'</th>',
+                '<th>'.__('End date').'</th>',
+                '<th>'.__('Entries').'</th>',
+                '<th>'.__('Date').'</th>',
+                '<th>'.__('Category').'</th>',
+                '<th>'.__('Author').'</th>',
+                '<th>'.__('Status').'</th>');
+			
+			# --BEHAVIOR-- adminEventHandlerEventsListHeaders
+			$this->core->callBehavior('adminEventHandlerEventsListHeaders',array('columns'=>&$columns));
 			$html_block =
                 '<table class="clear"><tr>'.
-                '<th colspan="2">'.__('Title').'</th>'.
-                '<th>'.__('Start date').'</th>'.
-                '<th>'.__('End date').'</th>'.
-                '<th>'.__('Entries').'</th>'.
-                '<th>'.__('Date').'</th>'.
-                '<th>'.__('Category').'</th>'.
-                '<th>'.__('Author').'</th>'.
-                '<th>'.__('Status').'</th>'.
-                '</tr>%s</table>';
+   			join('',$columns).
+            '</tr>%s</table>';
 
 			if ($enclose_block) {
 				$html_block = sprintf($enclose_block,$html_block);
@@ -113,19 +117,24 @@ class adminEventHandlertList extends adminGenericList
             $nb_entries .= '&amp;tab=bind-entries">'.$entries->f(0).'</a>';
 		}
 
+		$columns=array('<td class="nowrap">'.form::checkbox(array('entries[]'),$this->rs->post_id,'','','',!$this->rs->isEditable()).'</td>'.
+            '<td class="maximal"><a href="'.$this->core->getPostAdminURL($this->rs->post_type,$this->rs->post_id).'">'.
+            html::escapeHTML($this->rs->post_title).'</a></td>',
+			'<td class="nowrap'.' '.$event_class.'">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_startdt).'</td>',
+            '<td class="nowrap'.' '.$event_class.'">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_enddt).'</td>',
+            '<td class="nowrap">'.$nb_entries.'</td>',
+            '<td class="nowrap">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->post_dt).'</td>',
+            '<td class="nowrap">'.$cat_title.'</td>',
+            '<td class="nowrap">'.$this->rs->user_id.'</td>',
+            '<td class="nowrap status">'.$img_status.' '.$selected.' '.$protected.'</td>');
+		
+			# --BEHAVIOR-- adminEventHandlerEventsListBody
+			$this->core->callBehavior('adminEventHandlerEventsListBody',$this->rs,array('columns'=>&$columns));
+	
 		return
             '<tr class="line'.($this->rs->post_status != 1 ? ' offline' : '').' '.$event_class.'"'.
             ' id="p'.$this->rs->post_id.'">'.
-            '<td class="nowrap">'.form::checkbox(array('entries[]'),$this->rs->post_id,'','','',!$this->rs->isEditable()).'</td>'.
-            '<td class="maximal"><a href="'.$this->core->getPostAdminURL($this->rs->post_type,$this->rs->post_id).'">'.
-            html::escapeHTML($this->rs->post_title).'</a></td>'.
-            '<td class="nowrap'.' '.$event_class.'">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_startdt).'</td>'.
-            '<td class="nowrap'.' '.$event_class.'">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->event_enddt).'</td>'.
-            '<td class="nowrap">'.$nb_entries.'</td>'.
-            '<td class="nowrap">'.dt::dt2str(__('%Y-%m-%d %H:%M'),$this->rs->post_dt).'</td>'.
-            '<td class="nowrap">'.$cat_title.'</td>'.
-            '<td class="nowrap">'.$this->rs->user_id.'</td>'.
-            '<td class="nowrap status">'.$img_status.' '.$selected.' '.$protected.'</td>'.
+            join("",$columns).
             '</tr>';
 	}
 }

--- a/inc/index.event.php
+++ b/inc/index.event.php
@@ -400,4 +400,7 @@ if (!empty($_GET['xconv'])) {
     $message = __('Don\'t forget to validate your XHTML conversion by saving your post.');
 }
 
+# --BEHAVIOR-- adminEventHandlerBeforeEventTpl - to use a custom tpl e.g.
+$core->callBehavior('adminEventHandlerCustomEventTpl');
+
 include(dirname(__FILE__).'/../tpl/edit_event.tpl');

--- a/inc/index.events.php
+++ b/inc/index.events.php
@@ -139,6 +139,8 @@ if (!empty($_POST['entries']) && $action == 'author' && !empty($_POST['new_auth_
 	}
 }
 
+#--BEHAVIOR-- adminEventHandlerActionsManage
+$core->callBehavior('adminEventHandlerActionsManage',$eventHandler,$action);
 
 if (!$core->error->flag()) {
 	try {
@@ -369,13 +371,26 @@ $redir = $p_url.
 '&amp;page='.$page.
 '&amp;nb='.$nb_per_page;
 
+#behavior to customize different aspects of the events page :
+# params to manage the getEvents (add some db fields...)
+# sortby_combo : add some criterias to the sortby_combo filter
+# show_filters : boolean to tell if the filters must be displayed or not
+# redir : redirection url
+# hidden_fields
+
+$core->callBehavior('adminEventHandlerEventsPageCustomize',array('params'=>&$params,'sortby_combo'=>&$sortby_combo,'show_filters'=>&$show_filters,'redir'=>&$redir,'hidden_fields'=>&$hidden_fields));
+
 # Get events
 try {
 	$posts = $eventHandler->getEvents($params);
 	$counter = $eventHandler->getEvents($params,true);
 	$post_list = new adminEventHandlertList($core,$posts,$counter->f(0));
+	$core->callBehavior('adminEventHandlerEventsListCustom',array($posts,$counter,$post_list));
 } catch (Exception $e) {
 	$core->error->add($e->getMessage());
 }
+
+# --BEHAVIOR-- adminEventHandlerBeforeEventsTpl - to use a custom tpl e.g.
+$core->callBehavior('adminEventHandlerBeforeEventsTpl');
 
 include(dirname(__FILE__).'/../tpl/list_events.tpl');

--- a/inc/index.settings.php
+++ b/inc/index.settings.php
@@ -52,6 +52,9 @@ if ($action == 'savesettings') {
 		$s->put('public_map_type',$public_map_type,'string');
 		$s->put('public_extra_css',$public_extra_css,'string');
 
+		# --BEHAVIOR-- adminEventHandlerSettingsSave
+		$core->callBehavior("adminEventHandlerSettingsSave");
+		
 		$core->blog->triggerBlog();
 
 		http::redirect($p_url.'&part=settings&msg=save_settings&section='.$section);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,17 @@
+/* -- BEGIN LICENSE BLOCK ----------------------------------
+ *
+ * This file is part of eventHandler, a plugin for Dotclear 2.
+ *
+ * Copyright(c) 2015 Onurb Teva <dev@taktile.fr>
+ *
+ * Licensed under the GPL version 2.0 license.
+ * A copy of this license is available in LICENSE file or at
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * -- END LICENSE BLOCK ------------------------------------*/
+
+$(document).ready(function(){
+	$(window).bind('hashchange onhashchange', function (e) {
+		$("input[name='section']").val('#'+$.pageTabs.getLocationHash());
+	});
+});

--- a/locales/fr/main.po
+++ b/locales/fr/main.po
@@ -6,13 +6,14 @@ msgstr ""
 "Report-Msgid-Bugs-To: nikrou77+l10n@gmail.com\n"
 "POT-Creation-Date: 2014-11-18 18:07+0100\n"
 "PO-Revision-Date: 2014-12-08 22:20+0100\n"
-"Last-Translator: Jean-Christian Denis\n"
+"Last-Translator: Onurb Teva <dev@taktile.fr>\n"
 "Language-Team: franck@ouik.fr\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.7\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: inc/class.eventhandler.php:441
 #, php-format
@@ -213,10 +214,6 @@ msgstr "Date de fin :"
 #: _widgets.php:138
 msgid "Entries of an event"
 msgstr "Billets d'un événement"
-
-#: inc/index.event.php:541
-msgid "Entry has been successfully created."
-msgstr "Événements importés avec succès depuis eventdata"
 
 #: _admin.php:28 _admin.php:58 inc/index.event.php:520
 #: inc/index.events.php:493 inc/index.events.php:504
@@ -811,3 +808,25 @@ msgstr "au"
 msgid "Add this event to your iCalendar"
 msgstr "Ajouter cet événement à votre iCalendar"
 
+msgid "%d entry has been successfully bound %s"
+msgid_plural "%d entries have been successfully bound %s"
+msgstr[0] "%d billet a bien été lié %s"
+msgstr[1] "%d billets ont bien été liés %s"
+
+msgid "%d post has been successfully unbound from its events"
+msgid_plural "%d posts have been successfully unbound from their events"
+msgstr[0] "%d billet a été bien été détaché de ses événements"
+msgstr[1] "%d billets ont été bien été détachés de leurs événements"
+
+msgid "to the selected event"
+msgid_plural "to the selected events"
+msgstr[0] "à l'événement sélectionné"
+msgstr[1] "aux événements sélectionnés"
+
+msgid "Event #%d (%s) successfully unbound from %d related post"
+msgid_plural "Event #%d (%s) successfully unbound from %d related posts"
+msgstr[0] "L'événement n°%d (%s) a bien été séparé d'%d entrée liée"
+msgstr[1] "L'événement n°%d (%s) a bien été séparé de %d entrées liées"
+
+msgid "Event #%d (%s) has no related post to be unbound from."
+msgstr "L'événement n°%d (%s) n'a pas d'entrées liées."

--- a/tpl/edit_event.tpl
+++ b/tpl/edit_event.tpl
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title><?php echo __('Event handler'), ' - ', $page_title;?></title>
-    <script type=""text/javascript" src = "http://maps.google.com/maps/api/js?sensor=false"></script>
+    <script type="text/javascript" src = "http://maps.google.com/maps/api/js?sensor=false"></script>
     <?php
        echo
        dcPage::jsDatePicker().
@@ -149,6 +149,10 @@
 		</div>
 	      </div>
 	    </div>
+		<?php
+	       # --BEHAVIOR-- adminEventHandlerForm 
+	       $core->callBehavior('adminEventHandlerForm',isset($post) ? $post : null);
+		?>
 
 	    <p class="col"><label class="required" title="<?php echo __('Required field');?>"><?php echo __('Title:');?>
 		<?php echo form::field('post_title',20,255,html::escapeHTML($post_title),'maximal',2);?>
@@ -167,10 +171,6 @@
 	    <p class="area" id="notes-area"><label><?php echo __('Notes:');?></label>
 	      <?php echo form::textarea('post_notes',50,5,html::escapeHTML($post_notes),'',2);?>
 	    </p>
-	    <?php
-	       # --BEHAVIOR-- adminEventHandlerForm
-	       $core->callBehavior('adminEventHandlerForm',isset($post) ? $post : null);
-	    ?>
 	    <p>
 	      <input type="submit" value="<?php echo __('Save');?> (s)" tabindex="4" accesskey="s" name="save" />
 	      <?php if ($post_id):?>
@@ -199,6 +199,10 @@
       <?php $posts_list->display($page,$nb_per_page,'%s');?>
       <?php endif;?>
     </div>
+	<?php
+	       # --BEHAVIOR-- adminEventHandlerTab 
+	       $core->callBehavior('adminEventHandlerTab',isset($post) ? $post : null);	
+	?>
     <?php endif;?>
     <?php echo $footer;?>
     <?php dcPage::helpBlock('eventHandler');?>

--- a/tpl/list_events.tpl
+++ b/tpl/list_events.tpl
@@ -47,6 +47,7 @@
 	  <p><label for="lang" class="ib"><?php echo __('Lang:');?></label>
 	    <?php echo form::combo('lang',$lang_combo,$lang);?>
 	  </p>
+	  <?php $core->callBehavior('adminEventHandlerEventsCustomFilterDisplay');?>
 	</div>
 
 	<div class="cell filters-options">

--- a/tpl/settings.tpl
+++ b/tpl/settings.tpl
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title><?php echo __('Event handler').' - '.__('Settings');?></title>
-    <?php echo dcPage::jsPageTabs($default_tab);?>
+    <?php echo dcPage::jsPageTabs($default_tab).dcPage::jsLoad("index.php?pf=eventHandler/js/settings.js");?>
     <?php echo $header;?>
   </head>
   <body>
@@ -73,7 +73,6 @@
       </div>
       <?php endif;?>
       <p>
-	<input type="submit" name="save" value="<?php echo __('Save');?>"/>
 	<?php
 	   echo $core->formNonce().
 	form::hidden(array('p'),'eventHandler').
@@ -126,6 +125,13 @@
 	<?php endif;?>
       </div>
       <?php endif;?>
+	  
+	  <?php 
+		/*Add a adminEventHandlerSettings behavior handler to add a custom tab to the eventhander settings page
+		 and add a adminEventHandlerSettingsSave behavior handler to add save your custom settings.*/
+		$core->callBehavior("adminEventHandlerSettings");  ?>
+	  
+	  <input type="submit" name="save" value="<?php echo __('Save');?>"/>
     </form>
 
     <?php if ($active && $core->plugins->moduleExists('eventdata')):?>


### PR DESCRIPTION
* Fixed a bug related to deprecated behaviors in dotclear 2.6
- adminPostsActionsCombo
- adminPostsActionsHeaders
- adminPostsActionsContent
did not function anymore.
now replaced by
- adminPostsActionsPage

french translation strings in locales/fr/main.po updated
dotclear minimum version test added in _install.php

* Added plenty of behaviors to permit easy extension of EventHandler capabilities.

* fixed eventHandler::getEventsByPost() bug : wrong sql because of old mysql drivername specification.
* fixed "eventdata" bug : on entry (regular, not event), a wrong msgstr in locales/fr/main.po appeared.
* fixed _admin.php doBindUnBind actions callback to work either from post.php or from index.events.php.
***TODO*** unify all actions through dcPostActionsPage because it's messy and ugly

*typo fix in edit_event.tpl
*minor fix : settings reload after save keeps the actual tab opened (before : reverted to «activation» tab)