### PR TITLE
2 small problems solved

### DIFF
--- a/js/event-public-cal.js
+++ b/js/event-public-cal.js
@@ -50,7 +50,7 @@
 			success:function(data){
 				data=$(data);
 				if(data.find('rsp').attr('status')=='ok'){
-					$(target).find('table').replaceWith($(data).find('calendar').text());
+					$(target).find('table').replaceWith($($(data).find('calendar').text()).find("table"));
 					$(target).eventHandlerCalendar();
 					return false;
 				}else{

--- a/locales/fr/main.po
+++ b/locales/fr/main.po
@@ -13,6 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: _admin.php:27
 #: inc/class.admin.eventhandler.php:19
@@ -103,6 +104,9 @@ msgstr "Non terminé"
 #: inc/index.events.php:227
 msgid "Finished"
 msgstr "Terminé"
+
+msgid "Scheduled"
+msgstr "Programmé"
 
 #: _public.php:948
 msgid "Published date"


### PR DESCRIPTION
* French translations : added "Plural-Forms" headers and a missing translation

* There was a bug in the calendar widget month change : when « or » was clicked, the full <div class="calendar-array weekstart startonly"> was embedded in itself instead of simply replacing the table.