### PR TITLE
Fix a bug caused by the lack of TIMESTAMP function in sqlite

### DIFF
--- a/inc/class.eventhandler.php
+++ b/inc/class.eventhandler.php
@@ -98,20 +98,23 @@ class eventHandler
 			}
 			$now = date('Y-m-d H:i:s');
 
+			# sqlite does not understand the TIMESTAMP function but understands the 'Y-m-d H:i:s' format just fine
+			$timestamp = $this->con->driver() == 'sqlite' ? "" : " TIMESTAMP";
+
 			$params['sql'] .= $op[0] != '!' && $op[1] != '!' ? 'AND (' : 'AND ';
 
 			if (!empty($params['event_startdt']) && $op[0] != '!') {
-				$params['sql'] .= "EH.event_startdt ".$op[0]." TIMESTAMP '".$this->con->escape($params['event_startdt'])."'";
+				$params['sql'] .= "EH.event_startdt ".$op[0].$timestamp." '".$this->con->escape($params['event_startdt'])."'";
 			} elseif (empty($params['event_startdt']) && $op[0] != '!') {
-				$params['sql'] .= "EH.event_startdt ".$op[0]." TIMESTAMP '".$now."'";
+				$params['sql'] .= "EH.event_startdt ".$op[0].$timestamp." '".$now."'";
 			}
 
 			$params['sql'] .= $op[0] != '!' && $op[1] != '!' ? ' '.$op[2].' ' : '';
 
 			if (!empty($params['event_enddt']) && $op[1] != '!') {
-				$params['sql'] .= "EH.event_enddt ".$op[1]." TIMESTAMP '".$this->con->escape($params['event_enddt'])."'";
+				$params['sql'] .= "EH.event_enddt ".$op[1].$timestamp." '".$this->con->escape($params['event_enddt'])."'";
 			} elseif (empty($params['event_enddt']) && $op[1] != '!') {
-				$params['sql'] .= "EH.event_enddt ".$op[1]." TIMESTAMP '".$now."'";
+				$params['sql'] .= "EH.event_enddt ".$op[1].$timestamp." '".$now."'";
 			}
 
 			$params['sql'] .= $op[0] != '!' && $op[1] != '!' ? ') ' : ' ';


### PR DESCRIPTION
When adding an event calendar to the sidebar to the blog and clicking on
"all events", dotclear ends up in error with the message

near "'YYY-MM-DD HH:MM:DD'": syntax error (1)

with the date displayed the current date and time.
This is actually caused by an sql statement containing the TIMESTAMP
function, which sqlite does not recognize. This commit replaces all
occurrences of TIMESTAMP with nothing when the database connection is with an
sqlite database.