### PR TITLE
Admin darkmode integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+plugin eventHandler 2019.03.26
+==============================
+* Issue : style.css color are not suitable for admin darkmode.
+  Sets an alternative admin css (dark-style.css) when darkmode is enabled
+  - adminEventHandler::adminCss() returns css link according to darkmode user setting
+  - all hardcoded references to css/style.css replaced
+
 plugin eventHandler 2019-03-07
 ==============================
 * Fix issue #42. Archibve plugin name must be prefix by plugin-

--- a/_define.php
+++ b/_define.php
@@ -20,7 +20,7 @@ $this->registerModule(
 	/* Name */			"EventHandler",
 	/* Description*/	"Manage events on your blog",
 	/* Author */		"JC Denis, Nicolas Roudaire",
-	/* Version */		'2019.03.07',
+	/* Version */		'2019.03.26',
 	/* Properties */
 	array(
 		'permissions' => 'usage,contentadmin',

--- a/css/dark-style.css
+++ b/css/dark-style.css
@@ -1,0 +1,45 @@
+/*Admin css for darkmode*/
+/* Events table (posts_actions and events page) */
+td.eventhandler.scheduled,
+tr.line.eventhandler.scheduled:hover {
+    background: #7A9243;
+}
+td.eventhandler.ongoing,
+tr.line.eventhandler.ongoing:hover {
+    background: #A8A07D;
+}
+td.eventhandler.finished,
+tr.line.eventhandler.finished:hover {
+    background: #5F5F5F;
+}
+/* Events list (post page) */
+ul.event-list {
+    margin: 0 0 1em 0;
+    padding: 0;
+}
+ul.event-list li {
+    margin: 0;
+    padding: 0 0 0 1.3em;
+    list-style: none;
+    list-style-position: inside;
+}
+.event-node-scheduled {
+    background: transparent url("index.php?pf=eventHandler/css/imgs/event-node-scheduled.png") no-repeat left top;
+}
+.event-node-ongoing {
+    background: transparent url("index.php?pf=eventHandler/css/imgs/event-node-ongoing.png") no-repeat left top;
+}
+.event-node-finished {
+    background: transparent url("index.php?pf=eventHandler/css/imgs/event-node-finished.png") no-repeat left top;
+}
+a.event-unbind {
+    color : #999 !important;
+    border: none;
+}
+a.event-unbind:hover,
+a.eventUnbind:focus {
+    color : #2ef854 !important;
+}
+.datepicker {
+    width: 140px;
+}

--- a/inc/class.admin.eventhandler.php
+++ b/inc/class.admin.eventhandler.php
@@ -77,7 +77,7 @@ class adminEventHandler
 	# Headers, jQuery features to remove events from a post
 	public static function adminPostHeaders() {
 		return
-		'<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/css/style.css" />'.
+		$this::adminCss().
 		dcPage::jsLoad('index.php?pf=eventHandler/js/post.js');
 	}
 
@@ -145,7 +145,7 @@ class adminEventHandler
 				);
 				$ap->redirect(true);
 			} else {
-				$ap->beginPage('','<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/css/style.css" />');
+				$ap->beginPage('',$this::adminCss());
 				echo '<h3>'.__('Select events to link to entries').'</h3>';
 				$eventHandler = new eventHandler($core);
 
@@ -321,4 +321,14 @@ class adminEventHandler
 			//$core->error->add($e->getMessage());
 		}
 	}
+        
+        # Returns the admin css according to the darkmode setting
+        public static function adminCss(){
+            global $core;
+            $style="style.css";
+            if($core->auth->user_prefs->interface->darkmode==1){
+                $style="dark-style.css";
+            }
+            return '<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/css/'.$style.'" />'."\n";
+        }
 }

--- a/index.php
+++ b/index.php
@@ -36,7 +36,7 @@ $type = isset($_REQUEST['type']) ? $_REQUEST['type'] : 'eventhandler';
 $action = isset($_POST['action']) ? $_POST['action'] : '';
 
 # Common page header
-$header = '<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/css/style.css" />';
+$header = adminEventHandler::adminCss();
 
 # Common page footer
 $footer = '<hr class="clear"/><p class="right">';

--- a/tpl/edit_event.tpl
+++ b/tpl/edit_event.tpl
@@ -17,9 +17,9 @@
 	dcPage::jsConfirmClose('entry-form','comment-form').
 	# --BEHAVIOR-- adminEventHandlerHeaders
 	$core->callBehavior('adminEventHandlerHeaders').
-	dcPage::jsPageTabs($default_tab);
+	dcPage::jsPageTabs($default_tab).
+        $header;
 	?>
-	<link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/css/style.css"/>
 	<?php echo $next_headlink."\n".$prev_headlink;?>
     </head>
     <body>

--- a/tpl/list_events.tpl
+++ b/tpl/list_events.tpl
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title><?php echo __('Events');?></title>
-    <link rel="stylesheet" type="text/css" href="index.php?pf=eventHandler/css/style.css"/>
+    <?php echo $header;?>
     <?php echo dcPage::jsLoad('js/_posts_list.js');?>
     <?php echo dcPage::jsLoad('js/filter-controls.js');?>
     <script type="text/javascript">


### PR DESCRIPTION
Hi,
This is a minor correction for correct display of eventHandler admin when darkmode is activated.
The background colors used in the events list for example made the text unreadable.
I added `css/dark-style.css`
I added `adminEventHandler::adminCss()` method which returns the correct <link > according to the darkmode user setting
I replaced all the hard coded occurrences of style.css <link> tags by calls to `adminEventHandler::adminCss()`
